### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled command line

### DIFF
--- a/PiiScanner.Api/Controllers/ScanController.cs
+++ b/PiiScanner.Api/Controllers/ScanController.cs
@@ -310,9 +310,26 @@ public class ScanController : ControllerBase
         try
         {
             if (System.IO.File.Exists(request.FilePath))
-                System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{request.FilePath}\"");
+            {
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    UseShellExecute = false
+                };
+                startInfo.ArgumentList.Add("/select,");
+                startInfo.ArgumentList.Add(request.FilePath);
+                System.Diagnostics.Process.Start(startInfo);
+            }
             else
-                System.Diagnostics.Process.Start("explorer.exe", $"\"{folderPath}\"");
+            {
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    UseShellExecute = false
+                };
+                startInfo.ArgumentList.Add(folderPath);
+                System.Diagnostics.Process.Start(startInfo);
+            }
 
             return Ok();
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cyberprevs/PII-Scanner/security/code-scanning/36](https://github.com/cyberprevs/PII-Scanner/security/code-scanning/36)

Pour corriger proprement sans changer la fonctionnalité, il faut remplacer les appels `Process.Start(string, string)` par un `ProcessStartInfo` avec `FileName` figé (`explorer.exe`) et des arguments ajoutés via `ArgumentList`.  
Ainsi, on ne compose plus une ligne de commande unique interpolée avec une valeur utilisateur.

Dans `PiiScanner.Api/Controllers/ScanController.cs`, dans `OpenFolder` (zone lignes 310–316), remplacer :

- `Process.Start("explorer.exe", $"/select,\"{request.FilePath}\"");`
- `Process.Start("explorer.exe", $"\"{folderPath}\"");`

par :

- création d’un `ProcessStartInfo` avec `FileName = "explorer.exe"` et `UseShellExecute = false`,
- ajout de `"/select,"` + chemin comme arguments séparés pour le cas fichier,
- ajout de `folderPath` seul pour le cas dossier,
- `Process.Start(startInfo)`.

Aucun changement fonctionnel côté API HTTP ; uniquement un durcissement de l’exécution de processus.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
